### PR TITLE
Update Simple Icons dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # hexo-simpleicons
-<p align="center">
 
 ![Picture](https://raw.githubusercontent.com/nidbCN/hexo-simpleIcons/master/images/01.jpg)
+
+<div align="center">
 
 <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/simpleicons.svg" width=70 height=70/>
 
 Use [simple-icons](https://github.com/simple-icons/simple-icons) in your hexo blog.
-</p>
+</div>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-<img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/simpleicons.svg" width=70 height=70/>
+<img src="https://cdn.simpleicons.org/simpleicons/black/white" width=70 height=70 />
 
 Use [simple-icons](https://github.com/simple-icons/simple-icons) in your hexo blog.
 </div>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # hexo-simpleicons
+<p align="center">
 
 ![Picture](https://raw.githubusercontent.com/nidbCN/hexo-simpleIcons/master/images/01.jpg)
 
-![SimpleIcon](https://cdn.jsdelivr.net/npm/simple-icons@v4/icons/simpleicons.svg)
+<img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/simpleicons.svg" width=70 height=70/>
 
 Use [simple-icons](https://github.com/simple-icons/simple-icons) in your hexo blog.
+</p>
 
 ## Installation
 
@@ -22,7 +24,7 @@ Edit `_config.yml` and add:
 simple_icons:
   enable: true
   # The cdn base url you want to use, if you save the simple-icons in your server, just modify it to the url of your simple-icons storage.
-  cdn_url: "https://cdn.jsdelivr.net/npm/simple-icons@v4/icons/"
+  cdn_url: "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/"
   # The type you want to use, if you want use simple-icons npm package, modify it to package.
   type: "cdn"
   # The zoom size of your icon, in default, the value is 1.2. The icon will has a seem height of line, you can modify this value to resize the icon.
@@ -42,13 +44,8 @@ Install this package first.
 
 ### Writting
 
-Use
-
-```md
-{% icon [ICON NAME] %}
-```
-to add a simple-icons. If you use CDN, the icon will in a im attr, use package it will be a svg in HTML document directly.
+Use `{% icon [ICON NAME] [COLOR] %}` to add the `simple-icons` icon you'd like to include. Color is an optional second parameter to pass a color directly to the icon.
 
 You can use this tag in text or markdown headline but you **can not** use it in the hexo passage title.
 
-You can find `[ICON NAME]` in simple icon offical website: [SimpleIcons.org](https://simpleicons.org/)
+You can find `[ICON NAME]` and `[COLOR]` at the Simple Icons offical website: [SimpleIcons.org](https://simpleicons.org/)

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ hexo.extend.tag.register('icon', (args) => {
 		return `${icon_name} icon.`;
 
 	const icon_name = args[0];
+	const icon_color = args[1];
+
 	if (icon_name == undefined)
 		// Throw error when lack of arguments.
 		throw new TypeError("[hexo-simpleIcon]Icon name should be string not undefined!");
@@ -31,8 +33,8 @@ hexo.extend.tag.register('icon', (args) => {
 	if (config.type == undefined)
 		config.type = "cdn";
 	if (config.cdn_url == undefined)
-		config.cdn_url = "https://cdn.jsdelivr.net/npm/simple-icons@v4/icons/";
+		config.cdn_url = "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/";
 
 	const func = require('./libs/convertor');
-	return func(icon_name, config.type, config.cdn_url);
+	return func(icon_name, icon_color, config.type, config.cdn_url);
 });

--- a/libs/convertor.js
+++ b/libs/convertor.js
@@ -1,4 +1,4 @@
-module.exports = function toIcon(icon_name, type, cdn_url) {
+module.exports = function toIcon(icon_name, icon_color, type, cdn_url) {
     // Default svg.
     let icon_content = `Here should be ${icon_name}, but there is a wrong type configuration.`;
 
@@ -18,7 +18,7 @@ module.exports = function toIcon(icon_name, type, cdn_url) {
             break;
     }
 
-    return `<span id="simple-icons-${icon_name}" class="simple-icon" style="color: ${icon_color};">${icon_content}</span>`;
+    return icon_color != null ? `<span id="simple-icons-${icon_name}" class="simple-icon" style="color: ${icon_color};">${icon_content}</span>` : `<span id="simple-icons-${icon_name}" class="simple-icon">${icon_content}</span>`;
 }
 
 function urlCombine(base_url, file_name) {

--- a/libs/convertor.js
+++ b/libs/convertor.js
@@ -1,8 +1,6 @@
 module.exports = function toIcon(icon_name, type, cdn_url) {
     // Default svg.
-    const svg_content_default =
-        `Here should be ${icon_name}, but we can not get icon, please check your Internet connection or the contact website master.`;
-    let icon_content = "Here should be ${icon_name}, but there is a wrong type configuration.";
+    let icon_content = `Here should be ${icon_name}, but there is a wrong type configuration.`;
 
     switch ((type).toLowerCase()) {
         case "cdn":
@@ -20,9 +18,9 @@ module.exports = function toIcon(icon_name, type, cdn_url) {
             break;
     }
 
-    return `<span id="simple-icons-${icon_name}" class="simple-icon">${icon_content}</span>`;
+    return `<span id="simple-icons-${icon_name}" class="simple-icon" style="color: ${icon_color};">${icon_content}</span>`;
 }
 
-function urlCombine(base_url, addition) {
-    return base_url + (base_url.endsWith('/') ? addition : `/${addition}`);
+function urlCombine(base_url, file_name) {
+    return base_url.endsWith('/') ? base_url + file_name : base_url + `/${file_name}`;
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/nidbCN/hexo-simpleIcons#readme",
   "dependencies": {
-    "simple-icons": "^4.19.0"
+    "simple-icons": "latest"
   }
 }


### PR DESCRIPTION
PR updates the CDN link to always use the latest version of Simple Icons.
Also adds ability for users to color an icon, should they wish.

Worth noting, [we](https://github.com/simple-icons) now host a CDN of our own, defaulting to the brand color - but with light/dark mode coloring available. See [litomore/simple-icons-cdn](https://github.com/litomore/simple-icons-cdn) for more info.